### PR TITLE
change conf file destination path var

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: "Generate nexus conf file(s)"
   template:
     src: "{{ item }}.j2"
-    dest: "/opt/nexus-{{ nexus_version }}/bin/{{ item }}"
+    dest: "{{ nexus_linked_dir }}/bin/{{ item }}"
     owner: "{{ nexus.user }}"
     group: "{{ nexus.user }}"
     mode: 0755


### PR DESCRIPTION
The current path doesn't work if you are using a non-standard `nexus_versioned_dir`. If the linked dir won't work for some reason the other option would be to use `nexus_versioned_dir` here instead.
